### PR TITLE
Feat/#88 - DWAlert 컴포넌트화

### DIFF
--- a/SUSA24-iOS/SUSA24-iOS/Sources/Core/Components/DWAlertButton.swift
+++ b/SUSA24-iOS/SUSA24-iOS/Sources/Core/Components/DWAlertButton.swift
@@ -1,0 +1,244 @@
+//
+//  DWAlertButton.swift
+//  SUSA24-iOS
+//
+//  Created by taeni on 11/10/25.
+//
+
+import SwiftUI
+
+struct DWAlertButton {
+    let title: String
+    let style: ButtonStyle
+    let action: () -> Void
+
+    enum ButtonStyle {
+        case `default`
+        case destructive
+        case cancel
+
+        var defaultTitle: String {
+            switch self {
+            case .default: return "확인"
+            case .destructive: return "삭제"
+            case .cancel: return "취소"
+            }
+        }
+    }
+
+    init(
+        title: String? = nil,
+        style: ButtonStyle = .default,
+        action: @escaping () -> Void = {}
+    ) {
+        self.style = style
+        self.title = title ?? style.defaultTitle
+        self.action = action
+    }
+}
+
+
+struct DWAlertModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    
+    let title: String
+    let message: String?
+    let primaryButton: DWAlertButton
+    let secondaryButton: DWAlertButton?
+    
+    // 배경색 제스쳐로 화면 닫을 것인지
+    let tapToDismiss: Bool
+    
+    init(isPresented: Binding<Bool>, title: String, message: String?, primaryButton: DWAlertButton, secondaryButton: DWAlertButton? = nil, tapToDismiss: Bool = false) {
+        _isPresented = isPresented
+        self.title = title
+        self.message = message
+        self.primaryButton = primaryButton
+        self.secondaryButton = secondaryButton
+        self.tapToDismiss = tapToDismiss
+    }
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            
+            if isPresented {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        if !tapToDismiss { return }
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                            isPresented = false
+                        }
+                    }
+                
+                VStack(spacing: 16) {
+                    VStack(spacing: 6) {
+                        Text(title)
+                            .font(.titleSemiBold16)
+                            .foregroundStyle(.labelNormal)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        
+                        if let message {
+                            Text(message)
+                                .font(.bodyRegular14)
+                                .foregroundStyle(.labelNeutral)
+                                .multilineTextAlignment(.leading)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 10)
+                    
+                    HStack(spacing: 8) {
+                        if let secondaryButton {
+                            alertButton(secondaryButton, isPrimary: false)
+                                .padding(.trailing, 2)
+                        }
+                        alertButton(primaryButton, isPrimary: true)
+                    
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 14)
+                .frame(width: 300)
+                .background(.ultraThinMaterial)
+                .cornerRadius(20)
+                .transition(.scale(scale: 0.9).combined(with: .opacity))
+                .zIndex(1)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isPresented)
+    }
+    
+    private func alertButton(_ button: DWAlertButton, isPrimary: Bool) -> some View {
+        Button {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                isPresented = false
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                button.action()
+            }
+        } label: {
+            Text(button.title)
+                .font(.titleSemiBold16)
+                .foregroundStyle(textColor(for: button.style, isPrimary: isPrimary))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(backgroundColor(for: button.style, isPrimary: isPrimary))
+                .cornerRadius(100)
+        }
+        .buttonStyle(.plain)
+    }
+    
+    private func textColor(for style: DWAlertButton.ButtonStyle, isPrimary: Bool) -> Color {
+        switch style {
+        case .destructive:
+            return .white
+        case .cancel:
+            return .labelNormal
+        case .default:
+            return isPrimary ? .white : .labelNormal
+        }
+    }
+    
+    private func backgroundColor(for style: DWAlertButton.ButtonStyle, isPrimary: Bool) -> Color {
+        switch style {
+        case .destructive:
+            return .pointRed1
+        case .cancel:
+            return .labelAlternative.opacity(0.45)
+        case .default:
+            return isPrimary ? .primaryNormal : .labelAlternative.opacity(0.45)
+        }
+    }
+}
+
+extension View {
+    func dwAlert(
+        isPresented: Binding<Bool>,
+        title: String,
+        message: String? = nil,
+        primaryButton: DWAlertButton,
+        secondaryButton: DWAlertButton? = nil
+    ) -> some View {
+        modifier(
+            DWAlertModifier(
+                isPresented: isPresented,
+                title: title,
+                message: message,
+                primaryButton: primaryButton,
+                secondaryButton: secondaryButton
+            )
+        )
+    }
+    
+    func dwAlert(
+        isPresented: Binding<Bool>,
+        title: String,
+        message: String? = nil,
+        action: @escaping () -> Void = {}
+    ) -> some View {
+        dwAlert(
+            isPresented: isPresented,
+            title: title,
+            message: message,
+            primaryButton: DWAlertButton(title: "확인", action: action)
+        )
+    }
+}
+
+// MARK: - Preview
+//
+//#Preview("Alert 사용 방법") {
+//    struct PreviewContainer: View {
+//        @State private var showBasicAlert = false
+//        @State private var showDestructiveAlert = false
+//        @State private var showSingleAlert = true
+//        
+//        var body: some View {
+//            VStack(spacing: 20) {
+//                Button("기본 Alert") {
+//                    showBasicAlert = true
+//                }
+//                
+//                Button("Destructive Alert") {
+//                    showDestructiveAlert = true
+//                }
+//                
+//                Button("단일 버튼 Alert") {
+//                    showSingleAlert = true
+//                }
+//            }
+//            .dwAlert(
+//                isPresented: $showBasicAlert,
+//                title: "저장하시겠습니까?",
+//                message: "변경사항을 저장하시겠습니까?",
+//                primaryButton: DWAlertButton(title: "저장") {
+//                    print("저장됨")
+//                },
+//                secondaryButton: DWAlertButton(style: .cancel)
+//            )
+//            .dwAlert(
+//                isPresented: $showDestructiveAlert,
+//                title: "핀 덮어쓰기",
+//                message: "기존에 '부산 강서구 대저2동'에 저장된 핀이 있습니다. 기존 내용을 지우고 덮어쓸까요?",
+//                primaryButton: DWAlertButton(title: "덮어쓰기", style: .destructive) {
+//                    print("덮어쓰기 눌렀음")
+//                },
+//                secondaryButton: DWAlertButton(title: "취소", style: .cancel)
+//            )
+//            .dwAlert(
+//                isPresented: $showSingleAlert,
+//                title: "작업 완료",
+//                message: "모든 작업이 성공적으로 완료되었습니다."
+//            ) {
+//                print("확인을 눌렀음")
+//            }
+//        }
+//    }
+//    
+//    return PreviewContainer()
+//}


### PR DESCRIPTION
why?
- 공통 alert 컴포넌트 필요

<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #88 

## 📝 Summary  
<!-- 이 PR의 전체적인 변경 내용을 한두 문장으로 요약해주세요. 예시: "로그인 기능 오류를 수정했습니다." -->

Alert 컴포넌트를 구현했습니다.

## 🔨 What  
<!-- 
1. 어떤 작업(수정, 추가, 삭제 등)을 했는지 구체적으로 작성해주세요. 예시: "로그인 API 에러 처리 로직 추가, 로그인 UI 버튼 위치 조정"
2. UI 변경 등 시각적으로 확인이 필요한 경우, 아래에 스크린샷이나 캡처 이미지를 첨부해주세요.
-->

코드 구현을 위해 찾아보다가 알게 된 것, 같이 보아요
Alert deprecated 사건 [https://developer.apple.com/documentation/swiftui/alert](url)
Modal presentations [https://developer.apple.com/documentation/swiftui/modal-presentations](url)

저희 앱에서 공통으로 사용될 Alert 를 구현했습니다.
띄우고 싶은 화면 하단에 모디파이어 형식으로 작성하면 되고,
프리뷰 보시면 사용 예시 보일거에요!

버튼 스타일은 세개로 만들어놨는데 더 필요하다면 추가 하시면 됩니단~~!

<img width="248" height="433" alt="image" src="https://github.com/user-attachments/assets/4bce75df-8236-442a-b3cd-c208082ddbf1" />


## 👀 Review Notes  
<!-- 리뷰어에게 요청하거나 참고해야 할 사항을 작성해주세요. 예시: "중점적으로 봐줬으면 하는 부분, 테스트 방법, 논의가 필요한 부분 등" -->

더 확장성이 필요한 부분이 있다면 (말씀해주시거나) 직접 추가하시면 됩니다!